### PR TITLE
Json UI validation changes

### DIFF
--- a/dist/components/Form/field-mapper.js
+++ b/dist/components/Form/field-mapper.js
@@ -26,6 +26,7 @@ Object.defineProperty(exports, "GridTransfer", {
     return _gridTransfer.default;
   }
 });
+exports.ImportantSpan = void 0;
 Object.defineProperty(exports, "NumberField", {
   enumerable: true,
   get: function get() {
@@ -150,6 +151,8 @@ const useStyles = (0, _core.makeStyles)({
     marginTop: "20px"
   }
 });
+const ImportantSpan = exports.ImportantSpan = _styled.default.span(_templateObject || (_templateObject = _taggedTemplateLiteral([" color: red !important; "]))); // * Style Css
+
 const RenderSteps = _ref => {
   let {
     tabColumns,
@@ -275,8 +278,6 @@ const RenderColumns = _ref3 => {
   if (!(formElements !== null && formElements !== void 0 && formElements.length)) {
     return null;
   }
-  const ImportantSpan = _styled.default.span(_templateObject || (_templateObject = _taggedTemplateLiteral([" color: red !important; "]))); // * Style Css
-
   return /*#__PURE__*/React.createElement(React.Fragment, null, formElements.map((_ref4, key) => {
     let {
       Component,

--- a/src/lib/components/Form/field-mapper.js
+++ b/src/lib/components/Form/field-mapper.js
@@ -66,6 +66,8 @@ const useStyles = makeStyles({
     }
 })
 
+export const ImportantSpan = styled.span` color: red !important; `; // * Style Css
+
 const RenderSteps = ({ tabColumns, model, formik, data, onChange, combos, lookups, fieldConfigs, mode, handleSubmit }) => {
     const [skipped, setSkipped] = React.useState(new Set());
 
@@ -150,7 +152,6 @@ const RenderColumns = ({ formElements, model, formik, data, onChange, combos, lo
     if (!formElements?.length) {
         return null;
     }
-    const ImportantSpan = styled.span` color: red !important; `; // * Style Css
 
     return (
         <>


### PR DESCRIPTION
Changes to validate the JSON data subfields. 
Currently, for the JSON data type, we assume that the child fields are to be of type string.
Now added the changes to specify the validations for the child field (of JSON data type) as well.

We are expecting the presence of ``` ${field}Validations ``` field to specify the validation of the required field.

Sample fieldValidations

```
[
	{ 
		"field": "HOOKUP",
 		"type": "number",
 		"min": 0,
 		"max": 50,
 		"required": true
 	},
	 { 
		"field": "REV",
		 "type": "string",
		 "min": 0,
		 "max": 50,
		 "required": true 
	}
]
```

